### PR TITLE
restore dynamic versioning from git tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # typsht
 
+## development
+
+never skip pre-commit hooks - create a branch instead.
+
 ## versioning and releases
 
 tags use the format `v{major}.{minor}.{patch}a{alpha_number}` for alpha releases (e.g., `v0.0.1a0`, `v0.0.1a1`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typsht"
-version = "0.0.1a0"
+dynamic = ["version"]
 description = "type checker agnostic parallel type checking tool"
 readme = "README.md"
 authors = [{ name = "zzstoatzz", email = "thrast36@gmail.com" }]
@@ -38,11 +38,20 @@ dev = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "uv-dynamic-versioning>=0.7.0"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
 
 [tool.hatch.metadata]
 allow-direct-references = true
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+bump = true
+fallback-version = "0.0.0"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
restores uv-dynamic-versioning that was mistakenly removed.

also adds reminder to CLAUDE.md: never skip pre-commit hooks - create a branch instead.