### PR TITLE
fix: lazy-import pytest plugin to avoid runtime dependency

### DIFF
--- a/src/typsht/__init__.py
+++ b/src/typsht/__init__.py
@@ -2,9 +2,34 @@
 
 __version__ = "0.0.0"
 
-from typsht._internal.pytest_plugin import (
-    assert_no_errors,
-    assert_type_equals,
-    assert_type_error,
-)
 from typsht._internal.types import CheckerType
+
+__all__ = [
+    "CheckerType",
+    "assert_no_errors",
+    "assert_type_equals",
+    "assert_type_error",
+]
+
+
+def __getattr__(name: str):
+    """lazy import pytest-dependent helpers."""
+    if name in ("assert_no_errors", "assert_type_equals", "assert_type_error"):
+        try:
+            from typsht._internal.pytest_plugin import (
+                assert_no_errors,
+                assert_type_equals,
+                assert_type_error,
+            )
+        except ImportError as e:
+            if "pytest" in str(e):
+                raise ImportError(
+                    f"'{name}' requires pytest. install with: uv add pytest"
+                ) from None
+            raise
+        return {
+            "assert_no_errors": assert_no_errors,
+            "assert_type_equals": assert_type_equals,
+            "assert_type_error": assert_type_error,
+        }[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -7,6 +7,25 @@ import pytest
 from typsht._internal.types import SourceInput
 
 
+# regression test for https://github.com/zzstoatzz/typsht/issues/7
+def test_public_api_lazy_imports() -> None:
+    """verify CheckerType can be imported without triggering pytest import."""
+    # this should work without pytest being imported at module load time
+    from typsht import CheckerType
+
+    assert CheckerType.MYPY.value == "mypy"
+
+
+def test_assertion_helpers_available_with_pytest() -> None:
+    """verify assertion helpers can be imported when pytest is available."""
+    from typsht import assert_no_errors, assert_type_equals, assert_type_error
+
+    # just verify they're callable
+    assert callable(assert_no_errors)
+    assert callable(assert_type_equals)
+    assert callable(assert_type_error)
+
+
 def test_source_input_with_content() -> None:
     """test creating SourceInput with content."""
     source = SourceInput(content="def foo(): pass")


### PR DESCRIPTION
## Summary
- uses `__getattr__` for lazy loading of pytest-dependent assertion helpers
- CLI and `CheckerType` import work without pytest installed
- helpful error message when assertion helpers are used without pytest

## Test plan
- [x] `uv run --isolated --no-dev typsht "def foo(): pass"` works
- [x] `from typsht import CheckerType` works without pytest
- [x] `from typsht import assert_type_equals` gives helpful error without pytest
- [x] all 56 tests pass

fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)